### PR TITLE
Use Elixir 1.16 when it's available on CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ jobs:
     parallelism: 1
     docker:
       # Bump cache key version below when changing elixir version
-      - image: cimg/elixir:1.15
+      - image: cimg/elixir:1.16
         environment:
           MIX_ENV: test
           POSTGRES_USER: postgres


### PR DESCRIPTION
CircleCI doesn't support Elixir 1.16 yet. Once they do, this will fix the broken CI build.

Local tests pass, of course.